### PR TITLE
Support switching branches, skipping commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ One could build an image `FROM snarlysodboxer/hambone:<tag>` and add a Git repos
 
 ### Roadmap
 
+* TODO When rerunning instances.Apply() after a failed `git push`, a bug allows it to falsely succeed.
 * Create example specs for running `hambone` in Kubernetes
 * Add metrics
 * Document better

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -114,7 +114,7 @@ func NewInstance(pbInstance *pb.Instance, server *Server) *Instance {
 }
 
 // Apply creates or updates the instance in the stateStore
-func (instance *Instance) Apply() error {
+func (instance *Instance) Apply(skipCommit bool) error {
 	err := NamesEquate(instance)
 	if err != nil {
 		return err
@@ -147,7 +147,7 @@ func (instance *Instance) Apply() error {
 		}
 	}
 
-	err = updater.Commit()
+	err = updater.Commit(skipCommit)
 	if err != nil {
 		return err
 	}

--- a/pkg/instances/server.go
+++ b/pkg/instances/server.go
@@ -23,7 +23,7 @@ func NewInstancesServer(instancesDir, templatesDir string, stateStore state.Engi
 // Apply adds/updates the given Instance, applies it to Kubernetes if desired, and commits the changes, rolling back as necessary
 func (server *Server) Apply(ctx context.Context, pbInstance *pb.Instance) (*pb.Instance, error) {
 	instance := NewInstance(pbInstance, server)
-	err := instance.Apply()
+	err := instance.Apply(false)
 	if err != nil {
 		return pbInstance, err
 	}

--- a/pkg/state/etcd/etcd.go
+++ b/pkg/state/etcd/etcd.go
@@ -245,7 +245,7 @@ func (updater *etcdUpdater) Cancel(err error) error {
 }
 
 // Commit is expected to add/update the Instance in the state store
-func (updater *etcdUpdater) Commit() (erR error) {
+func (updater *etcdUpdater) Commit(_ bool) (erR error) {
 	instanceKey := getInstanceKey(updater.Instance.Name)
 
 	// at this point, OldInstance matches if present, we have a lock, and

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -17,7 +17,7 @@ var (
 type Updater interface {
 	Init() error
 	Cancel(error) error
-	Commit() error
+	Commit(bool) error
 	RunCleanupFuncs() error
 }
 


### PR DESCRIPTION
Sometimes with bulk updates, it's desired to skip commits until the last update. This supports that.

Sometimes it's desired to switch between branches programmatically. This supports that.